### PR TITLE
Resolve elixir 1.11 compile warning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,9 @@ defmodule ExULID.MixProject do
 
   # Run "mix help compile.app" to learn about applications.
   def application do
-    []
+    [
+      extra_applications: [:crypto]
+    ]
   end
 
   # Run "mix help deps" to learn about dependencies.


### PR DESCRIPTION
This resolves a warning when compiling with elixir 1.11
```
==> ex_ulid
Compiling 3 files (.ex)
warning: :crypto.strong_rand_bytes/1 defined in application :crypto is used by the current application but the current application does not depend on :crypto. To fix this, you must do one of:

  1. If :crypto is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :crypto is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :crypto, you may optionally skip this warning by adding [xref: [exclude: [:crypto]]] to your "def project" in mix.exs

  lib/ex_ulid/ulid.ex:32: ExULID.ULID.generate/1

Generated ex_ulid app
```
