### PR TITLE
Move Crockford encoding and decoding chars to functions for performance

### DIFF
--- a/lib/ex_ulid/crockford.ex
+++ b/lib/ex_ulid/crockford.ex
@@ -4,25 +4,22 @@ defmodule ExULID.Crockford do
   according to [Crockford's Base32](http://www.crockford.com/wrmg/base32.html).
   """
   @bits 5
-  @encoding '0123456789ABCDEFGHJKMNPQRSTVWXYZ'
+  @encoding ~c"0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+  for {char, index} <- Enum.with_index(@encoding) do
+    defp encoding(unquote(index)), do: unquote(char)
+
+    defp decoding(unquote(char)), do: unquote(index)
+  end
+
+  defp decoding(_), do: :error
 
   defmodule UnknownCharacterError do
     defexception [:message]
 
     def exception(char) do
-      msg = "a character could not be decoded, got: #{inspect char}"
+      msg = "a character could not be decoded, got: #{inspect(char)}"
       %UnknownCharacterError{message: msg}
     end
-  end
-
-  defp encoding, do: @encoding
-
-  defp decoding do
-    @encoding
-    |> Enum.with_index()
-    |> Enum.reduce(%{}, fn({char, index}, acc) ->
-         Map.put(acc, char, index)
-       end)
   end
 
   @spec encode32(binary | integer) :: binary
@@ -31,8 +28,10 @@ defmodule ExULID.Crockford do
     |> :binary.encode_unsigned()
     |> encode32()
   end
+
   # Pad or remove any leading zero
   def encode32(""), do: {:ok, ""}
+
   def encode32(data) do
     data = pad_bitlength(data, @bits)
     {:ok, encode32("", data)}
@@ -45,27 +44,30 @@ defmodule ExULID.Crockford do
   # then append the character to the accumulator.
   defp encode32(acc, <<bits::@bits, remainder::bits>>) do
     acc
-    |> Kernel.<>(<<Enum.at(encoding(), bits)>>)
+    |> Kernel.<>(<<encoding(bits)>>)
     |> encode32(remainder)
   end
+
   # Last remainder will be an empty binary,
   # the accumulator is now final, return it as the result.
   defp encode32(acc, <<>>), do: acc
 
   defp pad_bitlength(data, bitlength) when rem(bit_size(data), bitlength) == 0, do: data
+
   defp pad_bitlength(data, bitlength) when rem(bit_size(data), bitlength) > 0 do
     remainder = rem(bit_size(data), bitlength)
     <<a::size(remainder), remaining::bits>> = data
 
     if a > 0 do
       missing_bits = bitlength - remainder
-      <<(<<0::size(missing_bits)>>), (data::bits)>>
+      <<(<<0::size(missing_bits)>>), data::bits>>
     else
       <<remaining::bits>>
     end
   end
 
   def decode32("0"), do: {:ok, <<0>>}
+
   def decode32(string) do
     string = String.to_charlist(string)
     {:ok, decode32("", string)}
@@ -73,20 +75,21 @@ defmodule ExULID.Crockford do
     e in UnknownCharacterError -> {:error, e.message}
   end
 
-  defp decode32(acc, ''), do: pad_bitlength(acc, 8)
+  defp decode32(acc, ~c""), do: pad_bitlength(acc, 8)
+
   defp decode32(acc, charlist) do
     [char | remainder] = charlist
     decode32(acc, remainder, char)
   end
+
   defp decode32(acc, remainder, char) do
     mapped =
-      case Map.fetch(decoding(), char) do
-        {:ok, mapped} -> mapped
-        :error        -> raise(UnknownCharacterError, <<char>>)
+      with :error <- decoding(char) do
+        raise(UnknownCharacterError, <<char>>)
       end
 
     <<_::3, data::5>> = :binary.encode_unsigned(mapped)
 
-    decode32(<<(acc::bits), data::5>>, remainder)
+    decode32(<<acc::bits, data::5>>, remainder)
   end
 end


### PR DESCRIPTION
Issue/Task Number:

# Overview

The encoding and decoding in the Crockford module is sped up by using functions for the chars in the encoding scheme. This is similar to the Unicode implementation used in the Elixir standard library.

# Benchmark
## Baseline
```
Operating System: Linux
CPU Information: AMD Ryzen 7 4800H with Radeon Graphics
Number of Available Cores: 16
Available memory: 15.05 GB
Elixir 1.16.3
Erlang 25.3.2.12
Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
parallel: 1
inputs: none specified
Estimated total run time: 7 s


Benchmarking encode...
Type help for instructions on how to use fish
Name             ips        average  deviation         median         99th %
encode      124.07 K        8.06 μs   ±530.89%           7 μs          16 μs
Operating System: Linux
CPU Information: AMD Ryzen 7 4800H with Radeon Graphics
Number of Available Cores: 16
Available memory: 15.05 GB
Elixir 1.16.3
Erlang 25.3.2.12
Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
parallel: 1
inputs: none specified
Estimated total run time: 7 s


Benchmarking decode...

Name             ips        average  deviation         median         99th %
decode       47.57 K       21.02 μs    ±36.88%          21 μs          47 μs
```
## Improved
```
Operating System: Linux
CPU Information: AMD Ryzen 7 4800H with Radeon Graphics
Number of Available Cores: 16
Available memory: 15.05 GB
Elixir 1.16.3
Erlang 25.3.2.12
Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
parallel: 1
inputs: none specified
Estimated total run time: 7 s


Benchmarking encode...

Name             ips        average  deviation         median         99th %
encode      147.27 K        6.79 μs   ±633.59%           6 μs          13 μs
Operating System: Linux
CPU Information: AMD Ryzen 7 4800H with Radeon Graphics
Number of Available Cores: 16
Available memory: 15.05 GB
Elixir 1.16.3
Erlang 25.3.2.12
Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
parallel: 1
inputs: none specified
Estimated total run time: 7 s


Benchmarking decode...

Name             ips        average  deviation         median         99th %
decode      363.11 K        2.75 μs  ±2540.59%           2 μs           6 μs
```